### PR TITLE
Fix bug where Recommend button on grant modal disappears when typing a

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -42,4 +42,8 @@ class User < ActiveRecord::Base
 
   end
 
+  def can_manage?(employee)
+    employee.managers.include?(self)
+  end
+
 end

--- a/app/views/grants/edit_modal.html
+++ b/app/views/grants/edit_modal.html
@@ -15,7 +15,7 @@
     </th-textarea>
     <th-button type="create" ng-if="modal.context.canGrant" 
                ng-click="modal.confirm(modal.context)"> Grant </th-button>
-    <th-button type="create" ng-if="!modal.context.canGrant && !modal.context.grant" 
+    <th-button type="create" ng-if="!modal.context.canGrant && !modal.context.grant.approved"
                ng-click="modal.confirm(modal.context)">Recommend</th-button>
     <th-button type="cancel" ng-click="modal.dismiss()">Cancel</th-button>
   </div>


### PR DESCRIPTION
recommendation. Hide the Recommend button on the grant modal if the
grant has been approved. Allow non-managers to update their
recommendations.